### PR TITLE
fix: floating point

### DIFF
--- a/somesum.go
+++ b/somesum.go
@@ -2,17 +2,26 @@ package main
 
 import (
 	"fmt"
-	"math"
 	"time"
 )
 
+func pow(n uint64, m uint64) uint64 {
+	result := uint64(1)
+	for ; m > 0; m /= 2 {
+		if m%2 == 1 {
+			result *= n
+		}
+		n *= n
+	}
+	return result
+}
+
 func somesum(n uint64, m uint64) uint64 {
-	sum := 0.0
-	var i uint64
-	for i = 0; i <= n; i++ {
-        sum += math.Pow(float64(i), float64(m))
-    }
-    return uint64(sum)
+	sum := uint64(0)
+	for i := uint64(0); i <= n; i++ {
+		sum += pow(i, m)
+	}
+	return sum
 }
 
 func main() {


### PR DESCRIPTION
Using fp64 pow leads to errors. Provided uint version of pow make epic speedup.

 P.S. use `go fmt`